### PR TITLE
Make ChemBench pip-installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-In case you would like to cite this: 
+In case you would like to cite this:
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4054866.svg)](https://doi.org/10.5281/zenodo.4054866)
 
@@ -157,12 +157,10 @@ These benchmark datasets and the split induces have benn generated in this repo,
 ```bash
 git clone https://github.com/shenwanxiang/ChemBench.git
 cd ChemBench
-# add to PYTHONPATH
-echo export PYTHONPATH="\$PYTHONPATH:`pwd`" >> ~/.bashrc
-source ~/.bashrc
+pip install -e .
 ```
 
-### Usage-1: Load the Dataset and  MoleculeNet's Split Induces  
+### Usage-1: Load the Dataset and  MoleculeNet's Split Induces
 
 ```python
 from chembench import load_data
@@ -175,7 +173,7 @@ train_idx, valid_idx, test_idx = induces[2]
 ```
 ----
 
-### Usage-2: Load Dataset As Data Object 
+### Usage-2: Load Dataset As Data Object
 
 ```python
 from chembench import dataset
@@ -185,7 +183,7 @@ data.y
 data.description
 
 
-## regression 
+## regression
 dataset.load_Lipop()
 dataset.load_ESOL()
 dataset.load_FreeSolv()
@@ -223,8 +221,8 @@ print(len(induces1))
 print(len(induces2))
 ```
 
-For example, the chemical space of the ESOL dataset using 5fold cluster split : 
+For example, the chemical space of the ESOL dataset using 5fold cluster split :
 ![ESOL split chemical space](https://github.com/shenwanxiang/ChemBench/blob/master/chembench/cluster/cluster_split/cluster_split_results/ESOL/ESOL.png)
 
-the Kolmogorov-Smirnov statistic on the distribution for the pairwise groups(clusters): 
+the Kolmogorov-Smirnov statistic on the distribution for the pairwise groups(clusters):
 ![ESOL split distribution test](https://github.com/shenwanxiang/ChemBench/blob/master/chembench/cluster/cluster_split/cluster_split_results/ESOL/ESOL_stat_test.png)

--- a/chembench/__init__.py
+++ b/chembench/__init__.py
@@ -1,3 +1,5 @@
+__version__ = '0.1.0'
+
 import os
 from glob import glob
 import pandas as pd

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name='ChemBench',
           'pandas>=0.24.2'
       ],
       include_package_data=True,
-      package_data={'ChemBench': ['notebook/*']},
+      package_data={'chembench': ['notebook/*']},
       zip_safe=True,
 
       classifiers=(

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,41 @@
+import io
+import os
+import re
+
+from setuptools import find_packages, setup
+
+# Get the version from chembench/__init__.py
+# Adapted from https://stackoverflow.com/a/39671214
+this_directory = os.path.dirname(os.path.realpath(__file__))
+version_matches = re.search(r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+                            io.open(f'{this_directory}/chembench/__init__.py', encoding='utf_8_sig').read())
+if version_matches is None:
+    raise Exception('Could not determine CHEMBENCH version from __init__.py')
+__version__ = version_matches.group(1)
+
+with open('README.md', 'r') as fh:
+    long_description = fh.read()
+
+setup(name='ChemBench',
+      version=__version__,
+      author='Shen Wanxiang',
+      author_email='wanxiang.shen@u.nus.edu',
+      description='MoleculeNet benchmark dataset & MolMapNet dataset',
+      long_description=long_description,
+      long_description_content_type='text/markdown',
+      url='https://github.com/shenwanxiang/ChemBench',
+
+      packages=find_packages(),
+
+      install_requires=[
+          'numpy>=1.16.3', 
+          'tqdm>=4.32.1',
+          'pandas>=0.24.2'
+      ],      include_package_data=True,
+      zip_safe=True,
+
+      classifiers=(
+          'Programming Language :: Python :: 3',
+          'Operating System :: OS Independent',
+      ),
+      )

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ package_data = []
 for file_ending in data_file_endings:
     package_data += glob.glob(f'**/*{file_ending}', recursive=True)
 
+package_data = [os.path.relpath(p, 'chembench') for p in package_data]
+
 setup(name='ChemBench',
       version=__version__,
       author='Shen Wanxiang',

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,12 @@ setup(name='ChemBench',
       packages=find_packages(),
 
       install_requires=[
-          'numpy>=1.16.3', 
+          'numpy>=1.16.3',
           'tqdm>=4.32.1',
           'pandas>=0.24.2'
-      ],      include_package_data=True,
+      ],
+      include_package_data=True,
+      package_data={'ChemBench': ['notebook/*']},
       zip_safe=True,
 
       classifiers=(

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open('README.md', 'r') as fh:
 data_file_endings = ['.pkl', '.csv', '.idx', '.sdf', '.csv.gz']
 package_data = []
 for file_ending in data_file_endings:
-    package_data += glob.glob(f'**/{file_ending}', recursive=True)
+    package_data += glob.glob(f'**/*{file_ending}', recursive=True)
 
 setup(name='ChemBench',
       version=__version__,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import io
 import os
 import re
+import glob
 
 from setuptools import find_packages, setup
 
@@ -15,6 +16,11 @@ __version__ = version_matches.group(1)
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()
+
+data_file_endings = ['.pkl', '.csv', '.idx', '.sdf', '.csv.gz']
+package_data = []
+for file_ending in data_file_endings:
+    package_data += glob.glob(f'**/{file_ending}', recursive=True)
 
 setup(name='ChemBench',
       version=__version__,
@@ -33,7 +39,7 @@ setup(name='ChemBench',
           'pandas>=0.24.2'
       ],
       include_package_data=True,
-      package_data={'chembench': ['notebook/*']},
+      package_data={'chembench': package_data},
       zip_safe=True,
 
       classifiers=(


### PR DESCRIPTION
Hi!

This PR adds a `setup.py` to ChemBench in order to make it pip installable. This has the advantage that users don't have to clone and add the path to the local directory to their `PYTHONPATH` anymore. Additionally, ChemBench could now be published to pypi such that users could simply install it without any cloning. This would be great for projects that rely on ChemBench and want to add it to their `setup.py` or to their `requirements.txt` as a dependency.

Let me know what you think or if there is anything I can help with! Thanks :) 