### PR TITLE
Add release tools for PyPI

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,29 @@
+[bumpversion]
+current_version = 0.0.1-dev
+commit = True
+tag = False
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<release>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?
+serialize = 
+	{major}.{minor}.{patch}-{release}+{build}
+	{major}.{minor}.{patch}+{build}
+	{major}.{minor}.{patch}-{release}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = production
+first_value = dev
+values = 
+	dev
+	production
+
+[bumpverion:part:build]
+values = [0-9A-Za-z-]+
+
+[bumpversion:file:src/chembench/version.py]
+search = VERSION = '{current_version}'
+replace = VERSION = '{new_version}'
+
+[bumpversion:file:setup.cfg]
+search = version = {current_version}
+replace = version = {new_version}
+

--- a/README.md
+++ b/README.md
@@ -235,3 +235,25 @@ For example, the chemical space of the ESOL dataset using 5fold cluster split :
 
 the Kolmogorov-Smirnov statistic on the distribution for the pairwise groups(clusters): 
 ![ESOL split distribution test](https://github.com/shenwanxiang/ChemBench/blob/master/chembench/cluster/cluster_split/cluster_split_results/ESOL/ESOL_stat_test.png)
+
+
+## Making a Release
+
+After installing the package in development mode and installing
+`tox` with `pip install tox`, the commands for making a new release are contained within the `finish` environment
+in `tox.ini`. Run the following from the shell:
+
+```bash
+$ tox -e finish
+```
+
+This script does the following:
+
+1. Uses BumpVersion to switch the version number in the `setup.cfg` and
+   `src/chembench/version.py` to not have the `-dev` suffix
+2. Packages the code in both a tar archive and a wheel
+3. Uploads to PyPI using `twine`. Be sure to have a `.pypirc` file configured to avoid the need for manual input at this
+   step
+4. Push to GitHub. You'll need to make a release going with the commit where the version was bumped.
+5. Bump the version to the next patch. If you made big changes and want to bump the version by minor, you can
+   use `tox -e bumpversion minor` after.

--- a/src/chembench/version.py
+++ b/src/chembench/version.py
@@ -1,0 +1,5 @@
+__all__ = [
+    'VERSION',
+]
+
+VERSION = '0.0.1-dev'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,47 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+####################
+# Deployment tools #
+####################
+
+[testenv:bumpversion]
+commands = bumpversion {posargs}
+skip_install = true
+passenv = HOME
+deps =
+    bumpversion
+
+[testenv:build]
+skip_install = true
+deps =
+    wheel
+    setuptools
+commands =
+    python setup.py -q sdist bdist_wheel
+
+[testenv:release]
+skip_install = true
+deps =
+    {[testenv:build]deps}
+    twine >= 1.5.0
+commands =
+    {[testenv:build]commands}
+    twine upload --skip-existing dist/*
+
+[testenv:finish]
+skip_install = true
+passenv = HOME
+deps =
+    {[testenv:release]deps}
+    bumpversion
+commands =
+    bumpversion release
+    {[testenv:release]commands}
+    git push
+    bumpversion patch
+    git push
+whitelist_externals =
+    /usr/bin/git


### PR DESCRIPTION
Closes #6

This PR does the following:

1. Adds an importable version string in `chembench.version.VERSION`
2. Adds `.bumpversion.cfg`, which helps automatically manage the software version using BumpVersion
3. Adds `tox.ini`, which configures the `tox` automation tool
    - Add configuration for automatic version bumping and deployment to PyPI
4. Adds documentation on how to install/use tox to the README

## Usage

After installing the package in development mode with `pip install -e .` and installing
`tox` with `pip install tox`, the commands for making a new release are contained within the `finish` environment
in `tox.ini`. Run the following from the shell:

```bash
$ tox -e finish
```

This script does the following:

1. Uses BumpVersion to switch the version number in the `setup.cfg` and
   `src/chembench/version.py` to not have the `-dev` suffix
2. Packages the code in both a tar archive and a wheel
3. Uploads to PyPI using `twine`. If you want to avoid manually typing in your credentials every time, you can configure a  `.pypirc` file (see https://packaging.python.org/specifications/pypirc/)
4. Push to GitHub. You'll need to make a release going with the commit where the version was bumped.
5. Bump the version to the next patch. If you made big changes and want to bump the version by minor, you can
   use `tox -e bumpversion minor` after.

## Next Steps

@shenwanxiang after we discuss and you're confident that you understand what this code does, you can accept this PR, pull the new code from master locally, and run the `tox -e finish` command to deploy to PyPI. If everything goes well, this should automatically make a new commit for the version release and another for bumping the version to `0.0.2-dev`, then push it all to GitHub. Then we can check it all worked at https://pypi.org/project/chembench/ (right now there's nothing there)